### PR TITLE
Add missing GitHub Skills activity

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -39,6 +39,12 @@ activities = {
         "max_participants": 30,
         "participants": ["john@mergington.edu", "olivia@mergington.edu"]
     },
+    "GitHub Skills": {
+        "description": "Learn practical coding and collaboration with GitHub",
+        "schedule": "Wednesdays, 3:30 PM - 5:00 PM",
+        "max_participants": 25,
+        "participants": []
+    },
     "Soccer Team": {
         "description": "Join the school soccer team and compete in matches",
         "schedule": "Tuesdays and Thursdays, 4:00 PM - 5:30 PM",


### PR DESCRIPTION
## Summary
- Adds the missing `GitHub Skills` activity to the in-memory activities list.
- Makes the activity available through the existing `/activities` endpoint and UI rendering flow.

## Why
Issue #6 reports that the GitHub Skills activity is missing and registrations are time-sensitive.

## Changes
- Updated `src/app.py` to include:
  - `description`: Learn practical coding and collaboration with GitHub
  - `schedule`: Wednesdays, 3:30 PM - 5:00 PM
  - `max_participants`: 25
  - `participants`: []

Closes #6